### PR TITLE
Search config in home and config directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,12 @@ checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
@@ -68,6 +74,12 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -117,6 +129,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +187,17 @@ name = "exitcode"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -212,6 +256,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dirs",
  "dotenvy",
  "exitcode",
  "indoc",
@@ -249,6 +294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,12 +324,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -398,6 +469,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.72"
 clap = { version = "4.3.14", features = ["derive", "env"] }
+dirs = "5.0.1"
 dotenvy = "0.15.7"
 exitcode = "1.1.2"
 indoc = "2.0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -269,7 +269,7 @@ fn find_config_file() -> Result<(PathBuf, File), FindConfigFileError> {
     loop {
         let path = current_dir.join(&config);
         if let Ok(file) = File::open(&path) {
-            let path = pathdiff::diff_paths(&path, current_dir).unwrap_or(path);
+            let path = pathdiff::diff_paths(&path, working_dir).unwrap_or(path);
             return Ok((path, file));
         }
 
@@ -278,25 +278,25 @@ fn find_config_file() -> Result<(PathBuf, File), FindConfigFileError> {
         } else {
             break;
         }
+    }
 
-        // $HOME
-        if let Some(home_dir_path) = dirs::home_dir() {
-            let path = home_dir_path.join(&config);
-
-            if let Ok(file) = File::open(&path) {
-                return Ok((path, file));
-            }
-        }
-
-        // On Linux this will be $XDG_CONFIG_HOME
-        // Or just $HOME/.config if the above is not present
-        if let Some(config_dir_path) = dirs::config_dir() {
-            let path = config_dir_path.join(&config);
-            if let Ok(file) = File::open(&path) {
-                return Ok((path, file));
-            }
+    // $HOME
+    if let Some(home_dir_path) = dirs::home_dir() {
+        let path = home_dir_path.join(&config);
+        if let Ok(file) = File::open(&path) {
+            return Ok((path, file));
         }
     }
+
+    // On Linux this will be $XDG_CONFIG_HOME
+    // Or just $HOME/.config if the above is not present
+    if let Some(config_dir_path) = dirs::config_dir() {
+        let path = config_dir_path.join(&config);
+        if let Ok(file) = File::open(&path) {
+            return Ok((path, file));
+        }
+    }
+
     Err(FindConfigFileError::FileNotFound)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,19 +262,35 @@ fn run_output_loop(out_rx: Receiver<ChildEvent>) -> JoinHandle<()> {
 
 fn find_config_file() -> Result<(PathBuf, File), FindConfigFileError> {
     let config = PathBuf::from(DEFAULT_CONFIG_FILE);
-    let working_dir = env::current_dir()?;
-    let mut current_dir = working_dir.clone();
-    loop {
-        let path = current_dir.join(&config);
-        if let Ok(file) = File::open(&path) {
-            let path = pathdiff::diff_paths(&path, working_dir).unwrap_or(path);
-            return Ok((path, file));
-        }
 
-        if let Some(parent) = current_dir.parent() {
-            current_dir = PathBuf::from(parent);
-        } else {
-            break;
+    let working_dir = env::current_dir()?;
+    let mut target_dirs = vec![working_dir];
+
+    // On Linux this will be $XDG_CONFIG_HOME
+    // Or just $HOME/.config if the above is not present
+    if let Some(config_dir_path) = dirs::config_dir() {
+        target_dirs.push(config_dir_path)
+    }
+    // $HOME
+    if let Some(home_dir_path) = dirs::home_dir() {
+        target_dirs.push(home_dir_path)
+    }
+
+    // Look in current dir -> config -> home
+    for dir in target_dirs {
+        let mut current_dir = dir.clone();
+        loop {
+            let path = current_dir.join(&config);
+            if let Ok(file) = File::open(&path) {
+                let path = pathdiff::diff_paths(&path, dir).unwrap_or(path);
+                return Ok((path, file));
+            }
+
+            if let Some(parent) = current_dir.parent() {
+                current_dir = PathBuf::from(parent);
+            } else {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
This MR will add two more directories in which the config will be searched if not found in the current working dir and it's parents. 
It will look for config in `$HOME` if the env var is present and also `$XDG_HOME_CONFIG` or `$HOME/.config`
