### PR TITLE
Support multiple explicit config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Added support for configuration files in the user's home and config directories.
 - [#5](https://github.com/sunsided/k8sfwd/pull/5):
   Source files from the path hierarchy and special directories are now merged.
+- [#7](https://github.com/sunsided/k8sfwd/pull/7):
+  Multiple config files can now be specified by repeating the `--file` argument.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ tags are selected.
 
 The configuration is provided as a YAML file. 
 
-- If a file is specified on program launch via the `--file` argument, its configuration is loaded.
+- If one or more files are specified on program launch via the `--file` argument(s), their configuration is loaded.
 - If no configuration file is specified, `k8sfwd` will recursively look for a `.k8sfwd` file in 
   - the current directory hierarchy, 
   - your home directory and 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,9 +11,8 @@ use std::path::PathBuf;
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Sets a custom config file to load instead of .k8sfwd.
-    // TODO: Allow more than file
     #[arg(short = 'f', long = "file", value_name = "FILE", value_parser = config_file_exists)]
-    pub config: Option<PathBuf>,
+    pub config: Vec<PathBuf>,
 
     /// Sets a custom path to the kubectl binary.
     #[arg(

--- a/src/config/visit_tracker.rs
+++ b/src/config/visit_tracker.rs
@@ -1,0 +1,47 @@
+use same_file::is_same_file;
+use std::path::PathBuf;
+
+/// Tracks directories that were visited during a configuration scan.
+#[derive(Debug, Default)]
+pub struct VisitTracker {
+    visited: Vec<PathBuf>,
+}
+
+impl VisitTracker {
+    /// Tracks file duplications.
+    ///
+    /// This differs from [`track_directory`](Self::track_directory) in that
+    /// it canonicalizes the file path and registers the owning directory.
+    pub fn track_file_path(&mut self, file: &PathBuf) -> Result<bool, std::io::Error> {
+        if let Some(directory) = file.canonicalize()?.parent() {
+            let path_buf = directory.to_path_buf();
+            return self.track_directory(&path_buf);
+        }
+
+        Ok(false)
+    }
+
+    /// Tracks directory duplications.
+    pub fn track_directory(&mut self, dir: &PathBuf) -> Result<bool, std::io::Error> {
+        let visited = self.path_already_visited(dir)?;
+        if visited {
+            return Ok(true);
+        }
+
+        self.visited.push(dir.clone().canonicalize()?);
+        Ok(false)
+    }
+
+    /// Tests whether a path was already visited before.
+    fn path_already_visited(&self, test_path: &PathBuf) -> Result<bool, std::io::Error> {
+        for path in &self.visited {
+            match is_same_file(path, &test_path) {
+                Ok(true) => return Ok(true),
+                Ok(false) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+
+        Ok(false)
+    }
+}


### PR DESCRIPTION
This allows specifying the `--file` argument multiple times.