### PR TITLE
Add filters to forward only a part of the loaded configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Multiple config files can now be specified by repeating the `--file` argument.
 - [#8](https://github.com/sunsided/k8sfwd/pull/8):
   Added the `--verbose` command-line option for more detailed information on configuration sources.
+- [#9](https://github.com/sunsided/k8sfwd/pull/9):
+  Added filter command-line arguments that allows to specify a prefix for
+  the loaded targets. Only targets matching the prefix will be forwarded.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ Spawning child processes:
 
 ## Command-Line Options
 
+### Filters
+
+Targets can be selected through prefix filters specified on the command-line. Only
+targets (and target names) starting with the specified prefixes will be forwarded.
+In the following example, services starting with `foo` and `bar` will be selected:
+
+```shell
+k8sfwd foo bar
+```
+
+Filters can operate in combination with tags as well:
+
+```shell
+k8sfwd -t test foo bar
+```
+
 ### Tags
 
 Targets can be labeled with tags. When `k8sfwd` is started with one or more space-separated

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,7 +15,7 @@ pub struct Cli {
     #[arg(short = 'f', long = "file", value_name = "FILE", value_parser = config_file_exists)]
     pub config: Vec<PathBuf>,
 
-    /// Provides
+    /// Specifies the prefixes of the target configurations to select.
     #[arg(value_name = "FILTER", num_args = 1.., value_delimiter = ' ', allow_hyphen_values = false)]
     pub filters: Vec<TargetFilter>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: EUPL-1.2
 // SPDX-FileType: SOURCE
 
+use crate::target_filter::TargetFilter;
 use clap::Parser;
 use just_a_tag::TagUnion;
 use std::fs::File;
@@ -14,6 +15,14 @@ pub struct Cli {
     #[arg(short = 'f', long = "file", value_name = "FILE", value_parser = config_file_exists)]
     pub config: Vec<PathBuf>,
 
+    /// Provides
+    #[arg(value_name = "FILTER", num_args = 1.., value_delimiter = ' ', allow_hyphen_values = false)]
+    pub filters: Vec<TargetFilter>,
+
+    /// Specifies the tags of the targets to forward to.
+    #[arg(short, long, value_name = "TAGS", num_args = 1.., value_delimiter = ' ', allow_hyphen_values = false)]
+    pub tags: Vec<TagUnion>,
+
     /// Sets a custom path to the kubectl binary.
     #[arg(
         long,
@@ -22,10 +31,6 @@ pub struct Cli {
         default_value = "kubectl"
     )]
     pub kubectl: PathBuf,
-
-    /// Specifies the tags of the targets to forward to.
-    #[arg(short, long, value_name = "TAGS", num_args = 1.., value_delimiter = ' ', allow_hyphen_values = false)]
-    pub tags: Vec<TagUnion>,
 
     /// Enables verbose log outputs.
     #[arg(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,19 +177,14 @@ fn map_and_print_config(
     filters: Vec<TargetFilter>,
 ) -> HashMap<ConfigId, PortForwardConfig> {
     let mut map: HashMap<ConfigId, PortForwardConfig> = HashMap::new();
-    let mut config_index = 0;
-    for config in configs.into_iter() {
-        if !tags.is_empty() && !tags.matches_set(&config.tags) {
-            continue;
-        }
 
-        if !filters.matches(&config) {
-            continue;
-        }
+    let configs = configs
+        .into_iter()
+        .filter(|config| tags.is_empty() || tags.matches_set(&config.tags))
+        .filter(|config| filters.matches(config));
 
-        let id = ConfigId::new(config_index);
-        config_index += 1;
-
+    for (id, config) in configs.enumerate() {
+        let id = ConfigId::new(id);
         let padding = " ".repeat(id.to_string().len());
 
         if let Some(name) = &config.name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ fn map_and_print_config(
     filters: Vec<TargetFilter>,
 ) -> HashMap<ConfigId, PortForwardConfig> {
     let mut map: HashMap<ConfigId, PortForwardConfig> = HashMap::new();
-    for (id, config) in configs.into_iter().enumerate() {
+    let mut config_index = 0;
+    for config in configs.into_iter() {
         if !tags.is_empty() && !tags.matches_set(&config.tags) {
             continue;
         }
@@ -186,7 +187,9 @@ fn map_and_print_config(
             continue;
         }
 
-        let id = ConfigId::new(id);
+        let id = ConfigId::new(config_index);
+        config_index += 1;
+
         let padding = " ".repeat(id.to_string().len());
 
         if let Some(name) = &config.name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use crate::config::{
     PortForwardConfig, RetryDelay,
 };
 use crate::kubectl::{ChildEvent, Kubectl, RestartPolicy, StreamSource};
+use crate::target_filter::{MatchesAnyFilter, TargetFilter};
 use anyhow::Result;
 use clap::Parser;
 use just_a_tag::{MatchesAnyTagUnion, TagUnion};
@@ -22,6 +23,7 @@ mod banner;
 mod cli;
 mod config;
 mod kubectl;
+mod target_filter;
 
 fn main() -> Result<ExitCode> {
     dotenvy::dotenv().ok();
@@ -129,7 +131,7 @@ fn main() -> Result<ExitCode> {
 
     // Map out the config.
     println!("Forwarding to the following targets:");
-    let map = map_and_print_config(config.targets, cli.tags, cli.verbose);
+    let map = map_and_print_config(config.targets, cli.tags, cli.verbose, cli.filters);
     if map.is_empty() {
         eprintln!("No targets selected.");
         return exitcode(exitcode::OK);
@@ -172,10 +174,15 @@ fn map_and_print_config(
     configs: Vec<PortForwardConfig>,
     tags: Vec<TagUnion>,
     verbose: bool,
+    filters: Vec<TargetFilter>,
 ) -> HashMap<ConfigId, PortForwardConfig> {
     let mut map: HashMap<ConfigId, PortForwardConfig> = HashMap::new();
     for (id, config) in configs.into_iter().enumerate() {
         if !tags.is_empty() && !tags.matches_set(&config.tags) {
+            continue;
+        }
+
+        if !filters.matches(&config) {
             continue;
         }
 

--- a/src/target_filter.rs
+++ b/src/target_filter.rs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright 2023 Markus Mayer
+// SPDX-License-Identifier: EUPL-1.2
+// SPDX-FileType: SOURCE
+
+use crate::config::PortForwardConfig;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::convert::Infallible;
+use std::str::FromStr;
+
+/// A filter for selecting a target.
+#[derive(Debug, Clone)]
+pub struct TargetFilter {
+    filter: String,
+}
+
+impl TargetFilter {
+    pub fn is_empty(&self) -> bool {
+        self.filter.is_empty()
+    }
+}
+
+pub trait MatchesAnyFilter {
+    fn matches(&self, config: &PortForwardConfig) -> bool;
+}
+
+impl MatchesAnyFilter for TargetFilter {
+    fn matches(&self, config: &PortForwardConfig) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        if config.target.starts_with(&self.filter) {
+            return true;
+        }
+
+        // TODO: Add alias property
+
+        if let Some(name) = &config.name {
+            if name.starts_with(&self.filter) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl<T> MatchesAnyFilter for T
+where
+    T: AsRef<[TargetFilter]>,
+{
+    fn matches(&self, config: &PortForwardConfig) -> bool {
+        let this = self.as_ref();
+        if this.is_empty() {
+            return true;
+        }
+
+        for filter in this {
+            if filter.matches(&config) {
+                return true;
+            }
+        }
+
+        false
+    }
+}
+
+impl PartialEq for TargetFilter {
+    fn eq(&self, other: &Self) -> bool {
+        self.filter == other.filter
+    }
+}
+
+impl FromStr for TargetFilter {
+    type Err = Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self { filter: s.into() })
+    }
+}
+
+impl<'de> Deserialize<'de> for TargetFilter {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let filter = String::deserialize(deserializer)?;
+        Ok(Self { filter })
+    }
+}
+
+impl Serialize for TargetFilter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.filter)
+    }
+}


### PR DESCRIPTION
Targets can now be selected through prefix filters specified on the command-line. Only targets (and target names) starting with the specified prefixes will be forwarded. In the following example, services starting with `foo` and `bar` will be selected:

```shell
k8sfwd foo bar
```

Filters can operate in combination with tags as well:

```shell
k8sfwd -t test foo bar
```

In this case, only targets matching the prefix and the labels will be selected.