### PR TITLE
Fix noaccess retries

### DIFF
--- a/src/config/retry_delay.rs
+++ b/src/config/retry_delay.rs
@@ -11,7 +11,6 @@ pub struct RetryDelay(f64);
 
 impl RetryDelay {
     pub const NONE: RetryDelay = RetryDelay(0.0);
-    pub const NEVER: RetryDelay = RetryDelay(-1.0);
 
     pub fn from_secs(delay: f64) -> Self {
         Self(delay.max(0.0))

--- a/src/config/retry_delay.rs
+++ b/src/config/retry_delay.rs
@@ -11,6 +11,7 @@ pub struct RetryDelay(f64);
 
 impl RetryDelay {
     pub const NONE: RetryDelay = RetryDelay(0.0);
+    pub const NEVER: RetryDelay = RetryDelay(-1.0);
 
     pub fn from_secs(delay: f64) -> Self {
         Self(delay.max(0.0))

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -13,7 +13,6 @@ use std::process::{Command, ExitStatus, Stdio};
 use std::sync::mpsc::Sender;
 use std::thread::JoinHandle;
 use std::{io, process, thread};
-use anyhow::Error;
 
 #[cfg(not(windows))]
 const ENV_PATH_SEPARATOR: char = ':';

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -254,6 +254,13 @@ impl Kubectl {
                         match status.code().unwrap() {
                             1 => {
                                 // Kill the process if the exit code is 1
+                                out_tx
+                                    .send(ChildEvent::Exit(
+                                        id,
+                                        status,
+                                        RestartPolicy::WillRestartIn(RetryDelay::NEVER)
+                                    ))
+                                    .ok();
                                 break 'new_process Err(anyhow!("Command returned status code 1"));
                             }
                             _ => {}

--- a/src/kubectl.rs
+++ b/src/kubectl.rs
@@ -254,11 +254,7 @@ impl Kubectl {
                             1 => {
                                 // Kill the process if the exit code is 1
                                 out_tx
-                                    .send(ChildEvent::Exit(
-                                        id,
-                                        status,
-                                        RestartPolicy::WillRestartIn(RetryDelay::NEVER)
-                                    ))
+                                    .send(ChildEvent::Exit(id, status, RestartPolicy::None))
                                     .ok();
                                 break 'new_process Err(anyhow!("Command returned status code 1"));
                             }
@@ -327,6 +323,7 @@ pub enum ChildEvent {
 #[derive(Debug)]
 pub enum RestartPolicy {
     WillRestartIn(RetryDelay),
+    None,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,12 +256,13 @@ fn start_output_loop_thread(out_rx: Receiver<ChildEvent>) -> JoinHandle<()> {
                                     "{id}: Process exited with {} - retrying immediately",
                                     status
                                 );
-                            } else {
-                                eprintln!(
-                                    "{id}: Process exited with {} - shutting process down",
-                                    status
-                                );
                             }
+                        }
+                        RestartPolicy::None => {
+                            eprintln!(
+                                "{id}: Process exited with {} - shutting process down",
+                                status
+                            );
                         }
                     }
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,9 +251,14 @@ fn start_output_loop_thread(out_rx: Receiver<ChildEvent>) -> JoinHandle<()> {
                                     "{id}: Process exited with {} - will retry in {}",
                                     status, delay
                                 );
-                            } else {
+                            } else if delay == RetryDelay::NONE {
                                 eprintln!(
                                     "{id}: Process exited with {} - retrying immediately",
+                                    status
+                                );
+                            } else {
+                                eprintln!(
+                                    "{id}: Process exited with {} - shutting process down",
                                     status
                                 );
                             }


### PR DESCRIPTION
This PR will implement breaking out of the thread loop if the exit code of the `port-forward` call is 1 (#11). Before breaking out it will send a `ChildEvent::Exit` with a new `RestartPolicy::NEVER`