### PR TITLE
TCP keepalive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "socket2",
  "thiserror",
  "which",
 ]
@@ -413,6 +414,16 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ semver = { version = "1.0.20", features = ["serde"] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
 serde_yaml = "0.9.29"
+socket2 = "0.5.5"
 thiserror = "1.0.52"
 which = "4.4.2"
 

--- a/kind/crashie.yaml
+++ b/kind/crashie.yaml
@@ -44,7 +44,7 @@ spec:
     spec:
       containers:
         - name: crashie
-          image: sunside/crashie
+          image: sunside/crashie:0.4.0
           env:
             - name: CRASHIE_BIND_HTTP_ECHO
               value: "0.0.0.0:80"
@@ -54,8 +54,10 @@ spec:
               value: "0.0.0.0:40000"
             - name: CRASHIE_HTTP_LIVENESS_PROBE_PATH
               value: "/health/live"
+            - name: CRASHIE_SLEEP_DELAY_GRACE_PERIOD
+              value: "5"
             - name: CRASHIE_SLEEP_DELAY
-              value: "30"
+              value: "40"
             - name: CRASHIE_SLEEP_DELAY_STDDEV
               value: "30"
           startupProbe:
@@ -65,13 +67,12 @@ spec:
             initialDelaySeconds: 1
             periodSeconds: 1
             timeoutSeconds: 1
-            failureThreshold: 1
             successThreshold: 1
           readinessProbe:
             httpGet:
               path: /health/live
               port: 80
-            initialDelaySeconds: 0
+            initialDelaySeconds: 2
             periodSeconds: 1
             timeoutSeconds: 1
             failureThreshold: 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,8 +238,8 @@ fn start_output_loop_thread(out_rx: Receiver<ChildEvent>) -> JoinHandle<()> {
                 ChildEvent::Output(id, channel, message) => {
                     // TODO: use display name
                     match channel {
-                        StreamSource::StdOut => println!("{id}: {message}"),
-                        StreamSource::StdErr => eprintln!("{id}: {message}"),
+                        StreamSource::StdOut => println!("{id}: kubectl: {message}"),
+                        StreamSource::StdErr => eprintln!("{id}: kubectl: {message}"),
                     }
                 }
                 ChildEvent::Exit(id, status, policy) => {


### PR DESCRIPTION
The goal of this PR is to provide an optional TCP keepalive on the port forwards such that `kubectl` will notice disconnects early and k8sfwd can reconnect before the end-user application fails.